### PR TITLE
docs: fix missing period and missing comma in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The TouchDesigner executor for Rocketship. Establishes a connection with a Rocketship server, scans the network for Base COMPs with an 'rship' tag, and exposes their custom parameters to rship as targets.
 
-Notch TOPs also have first-class support. Similar to Base COMPs their parameters can be quickly turned into targets by tagging the Notch TOP 'rship'
+Notch TOPs also have first-class support. Similar to Base COMPs, their parameters can be quickly turned into targets by tagging the Notch TOP 'rship'.
 
 ## Setup
 


### PR DESCRIPTION
## Summary
- Adds the trailing period and missing comma after "Base COMPs" in the Notch TOPs paragraph.

Caught while preparing the public Pulse docs site for Cloudflare Pages — this README is the page shipped from this repo.

## Test plan
- [ ] README renders correctly on GitHub
- [ ] Bump submodule pointer in pulse-deploy after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)